### PR TITLE
UDP JSON Subscriber

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -151,7 +151,20 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
-    </dependencies>
+	    <dependency>
+	        <groupId>net.sf.json-lib</groupId>
+	        <artifactId>json-lib</artifactId>
+	        <version>2.4</version>
+            <classifier>jdk15</classifier>
+	        <scope>compile</scope>
+	    </dependency>
+	    <dependency>
+	        <groupId>xom</groupId>
+	        <artifactId>xom</artifactId>
+	        <version>1.1</version>
+            <scope>compile</scope>
+	    </dependency>
+      </dependencies>
     <build>
         <plugins>
             <plugin>

--- a/core/src/main/java/com/ning/metrics/meteo/subscribers/FileSubscriber.java
+++ b/core/src/main/java/com/ning/metrics/meteo/subscribers/FileSubscriber.java
@@ -80,7 +80,7 @@ class FileSubscriber implements Subscriber
                     map.put("timestamp", dateTime);
                     for (int j = 1; j < items.length; j++) {
                         double value = Double.valueOf(items[j]);
-                        map.put(subscriberConfig.getAttributes()[j], value);
+                        map.put(subscriberConfig.getAttributes()[j-1], value);
                     }
                     builder.add(new LinkedHashMap(map));
                 }

--- a/core/src/main/java/com/ning/metrics/meteo/subscribers/UdpJsonSubscriber.java
+++ b/core/src/main/java/com/ning/metrics/meteo/subscribers/UdpJsonSubscriber.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2010-2012 Ning, Inc.
+ *
+ * Ning licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.metrics.meteo.subscribers;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.Date;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import net.sf.json.JSONObject;
+import net.sf.json.JSONSerializer;
+import net.sf.json.xml.XMLSerializer;
+
+import org.apache.log4j.Logger;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+import com.espertech.esper.client.EPServiceProvider;
+import com.google.inject.Inject;
+
+/**
+ * A Subscriber which reads 1K of JSON as the event.
+ * 
+ * @author William Speirs <bill.speirs@gmail.com>
+ */
+class UdpJsonSubscriber implements Subscriber
+{
+    private final Logger log = Logger.getLogger(UdpJsonSubscriber.class);
+
+    private final EPServiceProvider esperSink;
+    private final UdpJsonSubscriberConfig config;
+    
+    private final DatagramSocket socket;
+    private final DatagramPacket packet;
+    
+    private Thread acceptThread;
+    private ExecutorService handlerPool;
+    boolean running = false;
+
+    @Inject
+    public UdpJsonSubscriber(UdpJsonSubscriberConfig config, EPServiceProvider esperSink) throws SocketException, UnknownHostException {
+        this.config = config;
+        this.esperSink = esperSink;
+        
+        this.socket = new DatagramSocket(config.getPort(), InetAddress.getByName("0.0.0.0"));
+        this.packet = new DatagramPacket(new byte[config.getPacketSize()], config.getPacketSize());
+        
+        log.info("Created UDP socket on port " + config.getPort() + " with packet size " + config.getPacketSize());
+    }
+
+    @Override
+    public void subscribe() {
+        // set our status to running
+        running = true;
+        
+        // create the handler pool
+        handlerPool = Executors.newCachedThreadPool();
+
+        // create our accepter thread
+        acceptThread = new Thread() {
+          @Override
+          public void run() {
+              while(running) {
+                  try {
+                      log.debug("Waiting on packet");
+                      socket.receive(packet);
+                      log.debug("Got packet: " + packet.getLength());
+                  } catch (IOException e) {
+                      log.error("Error receiving packet: " + e.getMessage());
+                  }
+                  
+                  // create and submit the worker to the thread pool
+                  handlerPool.submit(new PacketHandler(packet.getData()));
+              }
+          }
+        };
+        
+        acceptThread.setDaemon(true);
+        acceptThread.start();
+    }
+
+    @Override
+    public void unsubscribe() {
+        log.info("Unsubscribing...");
+        // stop the processing loop
+        running = false;
+        
+        // interrupt the thread if it's waiting
+        acceptThread.interrupt();
+        
+        try {
+            acceptThread.join();
+        } catch (InterruptedException e) {
+        }
+        
+        // shutdown the handler thread pool
+        handlerPool.shutdownNow();
+    }
+
+    protected class PacketHandler implements Runnable {
+        private final byte[] packetData;
+        
+        public PacketHandler(byte[] packetData) {
+            this.packetData = packetData;
+        }
+
+        @Override
+        public void run() {
+            log.debug("Running handler...");
+            final XMLSerializer serializer = new XMLSerializer(); 
+            JSONObject json = null;
+            
+            try {
+                json = (JSONObject)JSONSerializer.toJSON(new String(packetData));
+            } catch(ClassCastException e) {
+                log.error("Error converting packet to JSON: " + e.getMessage());
+                return;
+            } catch(Exception e) {
+                log.error("Got exception: " + e.getMessage());
+                return;
+            }
+            
+            // check for a timestamp, and add if not already there
+            if(!json.has("timestamp")) {
+                json.put("timestamp", new Date().getTime());
+            }
+
+            // set the root to the event output name
+            serializer.setRootName(config.getEventOutputName());
+            
+            final String xml = serializer.write(json);
+            final DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+
+            try {
+                final DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+                final Document document = dBuilder.parse(new ByteArrayInputStream(xml.getBytes()));
+                
+                esperSink.getEPRuntime().sendEvent(document);
+                log.debug("JSON event submitted: " + json);
+            } catch (ParserConfigurationException e) {
+                log.error("Error with parser configuration: " + e.getMessage());
+                return;
+            } catch (SAXException e) {
+                log.error("SAX Exception: " + e.getMessage());
+                return;
+            } catch (IOException e) {
+                log.error("IO Exception: " + e.getMessage());
+                e.printStackTrace();
+                return;
+            }
+        }
+    }
+}

--- a/core/src/main/java/com/ning/metrics/meteo/subscribers/UdpJsonSubscriber.java
+++ b/core/src/main/java/com/ning/metrics/meteo/subscribers/UdpJsonSubscriber.java
@@ -45,6 +45,23 @@ import com.google.inject.Inject;
 /**
  * A Subscriber which reads 1K of JSON as the event.
  * 
+ * The JSON is converted to an XML DOM Node guessing at the types.
+ * 
+ * To configure this in Esper, using something like this:
+ * &lt;event-type name="UDPEvents"&gt;
+ *   &lt;xml-dom root-element-name="UDPEvents" /&gt;
+ * &lt;/event-type&gt;
+ * 
+ * To configure this in meteo use something like this:
+ * {
+ *   "name": "UDP JSON",
+ *   "type": "com.ning.metrics.meteo.subscribers.UdpJsonSubscriber",
+ *   "@class": "com.ning.metrics.meteo.subscribers.UdpJsonSubscriberConfig",
+ *   "port": 5678,
+ *   "eventOutputName": "UDPEvents",
+ *   "enabled": true
+ * }
+ * 
  * @author William Speirs <bill.speirs@gmail.com>
  */
 class UdpJsonSubscriber implements Subscriber

--- a/core/src/main/java/com/ning/metrics/meteo/subscribers/UdpJsonSubscriberConfig.java
+++ b/core/src/main/java/com/ning/metrics/meteo/subscribers/UdpJsonSubscriberConfig.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2010-2012 Ning, Inc.
+ *
+ * Ning licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.metrics.meteo.subscribers;
+
+class UdpJsonSubscriberConfig extends SubscriberConfig
+{
+    private int port;
+    private int packetSize;
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public int getPacketSize() {
+        return packetSize == 0 ? 1024 : packetSize;
+    }
+
+    public void setPacketSize(int packetSize) {
+        this.packetSize = packetSize;
+    }
+
+}

--- a/core/src/main/java/com/ning/metrics/meteo/subscribers/UdpJsonSubscriberConfig.java
+++ b/core/src/main/java/com/ning/metrics/meteo/subscribers/UdpJsonSubscriberConfig.java
@@ -16,6 +16,11 @@
 
 package com.ning.metrics.meteo.subscribers;
 
+/**
+ * Configuration class for UdpJsonSubscriber.
+ * 
+ * @author William Speirs <bill.speirs@gmail.com>
+ */
 class UdpJsonSubscriberConfig extends SubscriberConfig
 {
     private int port;


### PR DESCRIPTION
I added a UDP JSON Subscriber. It receives JSON in UDP packets and adds the event. The types for everything are determined from the JSON packet, so you can setup this subscriber and send it all kinds of JSON packets and it will generate events for them without additional configuration needed.

I had written a unit test, but it throws a null pointer because there is no mocked version of the EPRuntime and I didn't want to bring Mockito into the project for just one unit test. I did have to bring 2 other dependencies in, and didn't have access to the parent pom to specify the version so I had to do so in-line.

I also fixed a minor bug in the FileSubscriber...

Thanks...

Bill-
